### PR TITLE
fix: wildcard added for `workspace.findFiles`

### DIFF
--- a/src/editor/definition.ts
+++ b/src/editor/definition.ts
@@ -22,7 +22,7 @@ export class DefinitionProvider implements VscodeDefinitionProvider {
     if (poLine.startsWith('#: ')) {
       const [path, line] = poLine.split(' ')[1].split(':');
 
-      return workspace.findFiles(path).then((files) => {
+      return workspace.findFiles(`**/${path}`, '**/node_modules/**').then((files) => {
         if (!files) return;
         const sourcePosition = new Position(+line - 1, 0);
 


### PR DESCRIPTION
Previously, move to definition from po file is only working same directories. it is not ideal for monorepo workspaces. So fix it to find files more widely but exclude `node_modules` directories.

btw, this is good extensions for me 😉 